### PR TITLE
Layout for forgot password page

### DIFF
--- a/app/src/app/pages/forgot-password/forgot-password.page.html
+++ b/app/src/app/pages/forgot-password/forgot-password.page.html
@@ -1,3 +1,6 @@
+
+
+
 <ion-content class="ion-padding">
 
   <ion-row class="forgot-pass-title">
@@ -19,23 +22,26 @@
     <ion-input
     mode="md"
     fill="outline"
-    placeholder="Email"
+    placeholder="Email address"
     type="email">
     </ion-input>
-  
-    <ion-text [routerLink]="['/forgot-password']">
-      <p>Already have an account? <span>Sign in</span></p>
+
+    <ion-text [routerLink]="['/login']">
+      <p>Already have an account?</p>
     </ion-text>
   
-    <ion-button [routerLink]="['/forgot-password']" class="login" size="large" expand="block">Send email </ion-button>
+    <ion-button [routerLink]="['/forgot-password']" class="send-email" size="large" expand="block">Send email </ion-button>
   </form>
  
 
    
   <ion-row class="sign-up">
     <ion-col>
-      <ion-text>Don't have an account? <span [routerLink]="['/sign-up']">Sign Up</span></ion-text>
+      <ion-text>
+        Don't have an account? <span [routerLink]="['/sign-up']">Sign Up</span>
+      </ion-text>
     </ion-col>
   </ion-row>
+
 
 </ion-content>

--- a/app/src/app/pages/forgot-password/forgot-password.page.scss
+++ b/app/src/app/pages/forgot-password/forgot-password.page.scss
@@ -31,3 +31,53 @@ ion-row.login-logo {
     }
     
 }
+
+form {
+    // background-color: red;
+    ion-input {
+        margin-bottom: 10px;
+        --padding-start: 20px;
+        --border-radius: 10px;
+        ion-button {
+            ion-icon {
+            color:  #44aa79;
+            }
+        }
+    }
+
+    ion-text {
+        padding-right: 40px;
+        text-align: right;
+        font-weight: 600;
+        font-size: 0.8rem;
+    
+    }
+
+    ion-button.send-email {
+        color: black;
+        --border-radius: 10px;
+        letter-spacing: 0;
+        font-size: 1.3rem;
+        --background: #44aa79;
+        --background-activated: #60b48b;
+        text-transform: none;
+    }
+}
+
+ion-row.sign-up {
+    margin-top: 20px;
+    ion-col {
+        text-align: center;
+        ion-text {
+            color: #757171;
+            font-size: 0.8rem;
+            font-weight: 600;
+            span {
+                color: black;
+            }
+            p {
+                margin-top: 20px;
+            }
+        }
+    }
+}

--- a/app/src/app/pages/forgot-password/forgot-password.page.ts
+++ b/app/src/app/pages/forgot-password/forgot-password.page.ts
@@ -1,6 +1,6 @@
 import { Component, Input, OnInit } from '@angular/core';
-import { IonButton, IonCol, IonContent, IonHeader, IonIcon, IonInput, IonItem, IonLabel, IonRow, IonText, IonTitle, IonToolbar } from '@ionic/angular/standalone';
-import {personOutline, personCircleOutline, eyeOutline, eyeOffOutline, lockClosedOutline} from 'ionicons/icons';
+import { IonBackButton, IonButton, IonButtons, IonCol, IonContent, IonHeader, IonIcon, IonInput, IonItem, IonLabel, IonRow, IonText, IonTitle, IonToolbar } from '@ionic/angular/standalone';
+import {personOutline, personCircleOutline, arrowBack, eyeOutline, eyeOffOutline, lockClosedOutline} from 'ionicons/icons';
 import { addIcons } from 'ionicons';
 import { RouterLink } from '@angular/router';
 
@@ -9,12 +9,12 @@ import { RouterLink } from '@angular/router';
   templateUrl: './forgot-password.page.html',
   styleUrls: ['./forgot-password.page.scss'],
   standalone: true,
-  imports: [IonContent, RouterLink, IonButton, IonInput, IonRow, IonCol, IonLabel, IonHeader, IonToolbar, IonTitle, IonIcon, IonText, IonItem]
+  imports: [IonContent, IonButtons, IonBackButton, RouterLink, IonButton, IonInput, IonRow, IonCol, IonLabel, IonHeader, IonToolbar, IonTitle, IonIcon, IonText, IonItem]
 })
 export class ForgotPasswordPage implements OnInit {
 
   constructor() {
-    addIcons({lockClosedOutline})
+    addIcons({lockClosedOutline, arrowBack})
    }
 
   ngOnInit() {

--- a/app/src/app/pages/login/login.page.html
+++ b/app/src/app/pages/login/login.page.html
@@ -46,7 +46,7 @@
    
   <ion-row class="sign-up">
     <ion-col>
-      <ion-text>Don't have an account? <span [routerLink]="['/forgot-password']">Sign Up</span></ion-text>
+      <ion-text>Don't have an account? <span [routerLink]="['/sign-up']">Sign Up</span></ion-text>
     </ion-col>
   </ion-row>
 


### PR DESCRIPTION
updated the forgot password page to have a similar layout to the login page

has a single email input and a button to send the email for password recovery (no functionality yet)

has links back to login page and also to the sign up page